### PR TITLE
Add code title feature #35

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-icons": "^4.2.0",
+    "rehype-code-titles": "^1.0.3",
     "rehype-highlight": "^5.0.0",
     "rehype-stringify": "^9.0.2",
     "remark-parse": "^10.0.0",

--- a/posts/dial-customization.md
+++ b/posts/dial-customization.md
@@ -24,14 +24,15 @@ Files to create:
 - CustomColours.h
 - CustomLookAndFeel.h/.cpp
 - Dial.h/.cpp
-  ![add-new-cpp-header.png](/images/dial-customization/add-new-cpp-header.png)
+
+![add-new-cpp-header.png](/images/dial-customization/add-new-cpp-header.png)
 
 Make sure all the files have been created and open your IDE.
 ![added-files.png](/images/dial-customization/added-files.png)
 
 Next, define the following custom colours in CustomColours.h:
 
-```c++
+```c++:CustomColours.h
 #pragma once
 #include <JuceHeader.h>
 
@@ -61,9 +62,7 @@ In this chapter, we will create a basic dial as shown below.
 
 First, I will show you the whole implementation of Dial class, and then I will pick up some particularly important member functions and explain them.
 
-Dial.h:
-
-```c++
+```c++:Dial.h
 #pragma once
 
 #include <JuceHeader.h>
@@ -77,9 +76,7 @@ public:
 };
 ```
 
-Dial.cpp:
-
-```c++
+```c++:Dial.cpp
 Dial::Dial()
 {
     setSliderStyle (juce::Slider::SliderStyle::RotaryVerticalDrag);
@@ -141,9 +138,7 @@ Even at 50%, four numbers is redundant(Left):
 
 Now, create an object of the customized Dial class and display it in the editor. Be careful not to forget to include Dail.h and CustomColours.h.
 
-MainComponent.h:
-
-```c++
+```c++:MainComponent.h
 #pragma once
 
 #include <JuceHeader.h>
@@ -160,9 +155,7 @@ private:
 };
 ```
 
-MainComponent.cpp:
-
-```c++
+```c++:MainComponent.cpp
 #include "MainComponent.h"
 
 MainComponent::MainComponent()
@@ -201,7 +194,7 @@ In this chapter, we will customize LookAndFeel class to create the following dia
 
 I will first show the overall implementation, and then explain each member function.
 
-```c++
+```c++:CustomLookAndFeel.h
 #pragma once
 
 #include <JuceHeader.h>
@@ -223,7 +216,7 @@ public:
 };
 ```
 
-```c++
+```c++:CustomLookAndFeel.cpp
 #include "CustomLookAndFeel.h"
 
 CustomLookAndFeel::CustomLookAndFeel() {};
@@ -308,7 +301,7 @@ juce::Label* CustomLookAndFeel::createSliderTextBox (juce::Slider& slider)
 
 [getSliderLayout()](https://docs.juce.com/master/classLookAndFeel__V2.html#a5bdac020795c695459eefdd7b911814e) is a function that returns the slider layout, which is the position of the slider and text box. By overriding this function, you can change the layout as you wish. In this case, we implemented it so that the text box is centered on the slider.
 
-```c++
+```c++:CustomLookAndFeel.cpp
 juce::Slider::SliderLayout CustomLookAndFeel::getSliderLayout (juce::Slider& slider)
 {
     auto localBounds = slider.getLocalBounds();
@@ -332,7 +325,7 @@ Before(left) & After(right):
 [drawRotraySlider()]() is the member function that has the most impact on the appearance of a rotary-style slider.
 In order to make it easier to understand which part of the implementation describes what, I divided the implementation into smaller parts and added corresponding images to each part.
 
-```c++
+```c++:CustomLookAndFeel.cpp
 ・・・
     juce::Path backgroundArc;
     backgroundArc.addCentredArc (bounds.getCentreX(),
@@ -351,7 +344,7 @@ In order to make it easier to understand which part of the implementation descri
 
 ![dial-background-arc.png](/images/dial-customization/dial-background-arc.png)
 
-```c++
+```c++:CustomLookAndFeel.cpp
 ・・・
     juce::Path valueArc;
     valueArc.addCentredArc (bounds.getCentreX(),
@@ -370,7 +363,7 @@ In order to make it easier to understand which part of the implementation descri
 
 ![dial-value-arc.png](/images/dial-customization/dial-value-arc.png)
 
-```c++
+```c++:CustomLookAndFeel.cpp
 ・・・
     juce::Path stick;
     auto stickWidth = lineW * 2.0f;
@@ -384,7 +377,7 @@ In order to make it easier to understand which part of the implementation descri
 
 ![dial-thumb.png](/images/dial-customization/dial-thumb.png)
 
-```c++
+```c++:CustomLookAndFeel.cpp
 ・・・
     g.fillEllipse (bounds.reduced (radius * 0.25));
 ```
@@ -400,7 +393,7 @@ To understand these codes, it is essential to have an understanding of the [juce
 
 [createSliderTextBox()]() is a member function for setting up a slider text box (juce::Label).
 
-```c++
+```c++:CustomLookAndFeel.cpp
 juce::Label* CustomLookAndFeel::createSliderTextBox (juce::Slider& slider)
 {
     auto* l = new juce::Label();
@@ -424,13 +417,11 @@ The most important function in this implementation part is [setInterceptsMouseCl
 
 When you have finished implementing CustomLookAndFeel, include this header file and create an object of this class.
 
-Dial.h:
-
-```c++
+```c++:Dial.h
 #include "CustomLookAndFeel.h"
 ```
 
-```c++
+```c++:Dial.h
 class Dial  : public juce::Slider
 {
 ・・・
@@ -441,9 +432,7 @@ private:
 
 Then, pass this object to [setLookAndFeel()](https://docs.juce.com/master/classComponent.html#a6f2c10cd9840844a5be16e5deeef6f50) in the constructor below. Also, as a promise, pass a nullptr to setLookAndFeel() in the destructor:
 
-Dial.cpp:
-
-```c++
+```c++:Dial.cpp
 Dial::Dial()
 {
 ・・・
@@ -476,9 +465,7 @@ In this chapter, we will add a feature that will mark the dial when it is clicke
 
 Override [paint()](https://docs.juce.com/master/classSlider.html#a443749317634c0080d522d090ae991a5) and branch the process by using [hasKeyboardFocus()](https://docs.juce.com/master/classComponent.html#abf76cf5c3550c5c83bc585f86429b397) to determine if the component has KeyboardFocus, and if true, the mark will be drawn.
 
-Dial.h:
-
-```c++
+```c++:Dial.h
 class Dial  : public juce::Slider
 {
 public:
@@ -490,9 +477,7 @@ public:
 };
 ```
 
-Dial.cpp:
-
-```c++
+```c++:Dial.cpp
 void Dial::paint (juce::Graphics& g)
 {
     juce::Slider::paint (g);
@@ -545,9 +530,7 @@ void Dial::paint (juce::Graphics& g)
 
 This is not enough, we need to pass true to [setWantsKeyboardFocus()](https://docs.juce.com/master/classComponent.html#a6a1f21a76b971d54870cb5c32c041055) so that the component can gain KeyboardFocus. Also, pass true to setWantsKeyboardFocus() to MainComponent so that when you click anywhere in the Editor other than the dial, the dial's KeyboardFocus will be lost.
 
-Dial.cpp:
-
-```c++
+```c++:Dial.cpp
 Dial::Dial()
 {
 ・・・
@@ -555,9 +538,7 @@ Dial::Dial()
 }
 ```
 
-MainComponent.cpp:
-
-```c++
+```c++:MainComponent.cpp
 MainComponent::MainComponent()
 {
 ・・・
@@ -620,7 +601,7 @@ If the build is successful, you should find BinaryBuilder in the Release directo
 
 Next, move BinaryBuilder to a directory under your path so that you can execute the command by simply typing BinaryBuilder.
 
-```text
+```text:CommandLine
 ~
 ❯❯❯ mv /Users/suzukikengo/JUCE/extras/BinaryBuilder/Builds/MacOSX/build/Release/BinaryBuilder /usr/local/bin
 ```
@@ -630,7 +611,7 @@ Create "Resources" directory under the DialTutorial project as the source and ta
 
 You can check how to use BinaryBuilder by typing only the commands, for example:
 
-```text
+```text:CommandLine
 ~/Desktop/DialTutorial
 ❯❯❯ BinaryBuilder
 
@@ -648,7 +629,7 @@ You can check how to use BinaryBuilder by typing only the commands, for example:
 
 In the case of this tutorial, the argument will look like this:
 
-```text
+```text:CommandLine
 ~/Desktop/DialTutorial
 ❯❯❯ BinaryBuilder Resources Resources FuturaMedium
 
@@ -672,7 +653,7 @@ Then follow the steps below to load Resources directory into Projucer.
 
 Now, include FuturaMedium.h in CustomLookAndFeel.h.
 
-```c++
+```c++:CustomLookAndFeel.h
 #include "../Resources/FuturaMedium.h"
 ```
 
@@ -680,9 +661,7 @@ Now, include FuturaMedium.h in CustomLookAndFeel.h.
 
 Create Futura Medium font by calling [createSystemTypefaceFor()](https://docs.juce.com/master/classTypeface.html#a67bf5a42f6227ba6f5c9af2a23b0bb48) and set it as the default sans-serif font by passing it to [setDefaultSansSerifTypeface()](https://docs.juce.com/master/classLookAndFeel.html#ad6764bcf3fbb1983287379f2ed034337).
 
-CustomLookAndFeel.cpp:
-
-```c++
+```c++:CustomLookAndFeel.cpp
 CustomLookAndFeel::CustomLookAndFeel()
 {
     auto futuraMediumFont = juce::Typeface::createSystemTypefaceFor (FuturaMedium::FuturaMedium01_ttf,
@@ -695,13 +674,11 @@ CustomLookAndFeel::CustomLookAndFeel()
 
 Now, to apply this font, we just need to pass an object of the CustomLookAndFeel class to [setDefaultLookAndFeel()](https://docs.juce.com/master/classLookAndFeel.html#a0d2cc7f39cb3804d68a6fd2a723d05a4) in MainComponent.
 
-MainComponent.h:
-
-```c++
-#inlcude "CustomLookAndFeel.h"
+```c++:MainComponent.h
+#include "CustomLookAndFeel.h"
 ```
 
-```c++
+```c++:MainComponent.h
 class MainComponent  : public juce::Component
 {
 ・・・
@@ -712,9 +689,7 @@ private:
 };
 ```
 
-MainComponent.cpp:
-
-```c++
+```c++:MainComponent.cpp
 MainComponent::MainComponent()
 {
 ・・・
@@ -733,9 +708,7 @@ MainComponent::~MainComponent()
 
 Oops, the text was too small, so make it a little bigger before you build it.
 
-CustomLookAndFeel.cpp:
-
-```c++
+```c++:CustomLookAndFeel.cpp
 juce::Label* CustomLookAndFeel::createSliderTextBox (juce::Slider& slider)
 {
 ・・・
@@ -758,7 +731,7 @@ In this chapter, we will add a feature to multiply the sensitivity by 0.1 while 
 
 Override [mouseDrag()](https://docs.juce.com/master/classSlider.html#a6e117b6ba93f9a1954c52be4b4dfc873) and make it conditional by isShiftDown() so that the first argument of setVelocityModeParameters() is set to 0.1 if true, and 1.0 as usual if false.
 
-```c++
+```c++:Dial.h
 class Dial  : public juce::Slider
 {
 public:
@@ -766,7 +739,7 @@ public:
     void mouseDrag (const juce::MouseEvent& event) override;
 ```
 
-```c++
+```c++:Dial.cpp
 void Dial::mouseDrag (const juce::MouseEvent& event)
 {
     juce::Slider::mouseDrag (event);
@@ -794,9 +767,7 @@ Since the dial text box is a juce::Label object returned by createSliderTextBox(
 
 First, I will show the overall implementation of CustomLabel class, and then explain each member function.
 
-CustomLookAndFeel.h:
-
-```c++
+```c++:CustomLookAndFeel.h
 class CustomLookAndFeel : public juce::LookAndFeel_V4
 {
 public:
@@ -831,9 +802,7 @@ public:
 ・・・
 ```
 
-CustomLookAndFeel.cpp
-
-```c++
+```c++:CustomLookAndFeel.cpp
 juce::String CustomLookAndFeel::CustomLabel::initialPressedKey = "";
 
 CustomLookAndFeel::CustomLookAndFeel()
@@ -845,7 +814,7 @@ CustomLookAndFeel::CustomLookAndFeel()
 
 Override [createEditorComponent()](https://docs.juce.com/master/classLabel.html#a87b2717e5c855b64346b70a908eabc13) to set the details of the TextEditor object, which is called when the text box label goes into edit mode.
 
-```c++
+```c++:CustomLookAndFeel.h
 juce::TextEditor* createEditorComponent() override
 {
     auto* ed = juce::Label::createEditorComponent();
@@ -871,7 +840,7 @@ Then it is also important to use [setIndents()](https://docs.juce.com/master/cla
 
 [editorShown()](https://docs.juce.com/master/classLabel.html#a5260dfecf51d5f4822ea7072cb2d4cb6) is a function that is called when a TextEditor object appears.
 
-```c++
+```c++:CustomLookAndFeel.h
 void editorShown (juce::TextEditor* editor) override
 {
     getParentComponent()->setMouseCursor (juce::MouseCursor::NoCursor);
@@ -890,7 +859,7 @@ It is not cool to leave it like this, so we call [clear()](https://docs.juce.com
 
 [editorAboutToBeHidden()](https://docs.juce.com/master/classLabel.html#a94b4571677d5ac3c0ebfc7d171aa9ba6) is a function that is called when the editing mode is terminated. editorShown() implemented the process of hiding the mouse cursor, so here we implement the process of making the mouse cursor visible.
 
-```c++
+```c++:CustomLookAndFeel.h
 void editorAboutToBeHidden (juce::TextEditor * ed) override
 {
     getParentComponent()->setMouseCursor (juce::MouseCursor::NormalCursor);
@@ -901,7 +870,7 @@ void editorAboutToBeHidden (juce::TextEditor * ed) override
 
 Change the return value of createSliderTextBox() from juce::Label to CustomLabel.
 
-```c++
+```c++:CustomLookAndFeel.h
 class CustomLookAndFeel : public juce::LookAndFeel_V4
 {
 public:
@@ -909,7 +878,7 @@ public:
     CustomLabel* createSliderTextBox (juce::Slider& slider) override;
 ```
 
-```c++
+```c++:CustomLookAndFeel.cpp
 CustomLookAndFeel::CustomLabel* CustomLookAndFeel::createSliderTextBox (juce::Slider& slider)
 {
     auto* l = new CustomLabel();
@@ -929,7 +898,7 @@ CustomLookAndFeel::CustomLabel* CustomLookAndFeel::createSliderTextBox (juce::Sl
 
 To change the color of the caret from the default blue to red, override [createCaretComponent()](https://docs.juce.com/master/classLookAndFeel__V2.html#a8dbedf25e46dffd17384ae01e822dac4).
 
-```c++
+```c++:CustomLookAndFeel.h
 class CustomLookAndFeel : public juce::LookAndFeel_V4
 {
 public:
@@ -938,7 +907,7 @@ public:
 };
 ```
 
-```c++
+```c++:CustomLookAndFeel.cpp
 juce::CaretComponent* CustomLookAndFeel::createCaretComponent (juce::Component* keyFocusOwner)
 {
     auto caret = new juce::CaretComponent (keyFocusOwner);
@@ -955,7 +924,7 @@ juce::CaretComponent* CustomLookAndFeel::createCaretComponent (juce::Component* 
 
 Override [keyPressed()](https://docs.juce.com/master/classComponent.html#ab063a5c631854864da09106abec78a86) so that the dial can detect the keystrokes and switch to edit mode.
 
-```c++
+```c++:Dial.h
 class Dial  : public juce::Slider
 {
 public:
@@ -966,7 +935,7 @@ public:
 
 It responds only to numeric keys, and when a numeric key is pressed, the value of that key is assigned to the static variable initialPressedKey. This variable will be the initial value when the TextEditor object is displayed. If this is not implemented, the first numeric key pressed will only be treated as a trigger to switch to edit mode, and the value of that key will be ignored.
 
-```c++
+```c++:Dial.cpp
 bool Dial::keyPressed (const juce::KeyPress& k)
 {
     char numChars[] = "0123456789";
@@ -1003,7 +972,7 @@ In this chapter, we will make some minor settings for the mouse cursor when cont
 
 In the current Dial, the mouse cursor disappears when you start dragging, but not the moment you click. To make the mouse cursor disappear even at this moment, override [mouseDown()](https://docs.juce.com/master/classSlider.html#a66f2c67d6de570fa0d123ae2b9b394f7) and pass [juce::MouseCursor::NoCursor](https://docs.juce.com/master/classMouseCursor.html#a5de22a8c3eb06827ac11352e76eb9a97a765994c253a794c44b2a919f39738917) to [setMouseCursor()](https://docs.juce.com/master/classComponent.html#ab8c631fc3fb881ca94a9b7edcf58636f).
 
-```c++
+```c++:Dial.h
 class Dial  : public juce::Slider
 {
 public:
@@ -1011,7 +980,7 @@ public:
     void mouseDown (const juce::MouseEvent& event) override;
 ```
 
-```c++
+```c++:Dial.cpp
 void Dial::mouseDown (const juce::MouseEvent& event)
 {
     juce::Slider::mouseDown (event);
@@ -1024,7 +993,7 @@ void Dial::mouseDown (const juce::MouseEvent& event)
 
 Then, we pass [juce::MouseCursor::NormalCursor](https://docs.juce.com/master/classMouseCursor.html#a5de22a8c3eb06827ac11352e76eb9a97aa05a8960e2a3e32bfad68fdcb31a1511) to setMouseCursor() so that the mouse cursor will appear when we have finished clicking or dragging.
 
-```c++
+```c++:Dial.h
 class Dial  : public juce::Slider
 {
 public:
@@ -1032,7 +1001,7 @@ public:
     void mouseUp (const juce::MouseEvent& event) override;
 ```
 
-```c++
+```c++:Dial.cpp
 void Dial::mouseUp (const juce::MouseEvent& event)
 {
     juce::Slider::mouseUp (event);

--- a/posts/gigaverb-gen-juce.md
+++ b/posts/gigaverb-gen-juce.md
@@ -60,7 +60,7 @@ Set Header Search Paths for Debug and Release.
 
 In my case, PROJECT_DIR is the following Path:
 
-```bash
+```bash:CommandLine
 ~/Documents/MyProject/Gigaverb/Builds/MacOSX
 ❯❯❯ xcodebuild -showBuildSettings | grep "PROJECT_DIR"
     PROJECT_DIR = /Users/suzukikengo/Documents/MyProject/Gigaverb/Builds/MacOSX
@@ -74,14 +74,14 @@ If the Header Search Paths are set correctly, the build will succeed.
 
 Implement the following using APVTS.
 
-```c++
+```c++:PluginProcessor.h
 #pragma once
 
 #include <JuceHeader.h>
 #include "gen_exported.h"
 ```
 
-```c++
+```c++:PluginProcessor.cpp
 class GigaverbAudioProcessor  : public juce::AudioProcessor, public juce::AudioProcessorValueTreeState::Listener
 {
 public:
@@ -106,7 +106,7 @@ private:
 };
 ```
 
-```c++
+```c++:PluginProcessor.cpp
 GigaverbAudioProcessor::GigaverbAudioProcessor() : m_CurrentBufferSize (0)
 {
     m_C74PluginState = (CommonState*) gen_exported::create (44100, 64);
@@ -129,7 +129,7 @@ GigaverbAudioProcessor::GigaverbAudioProcessor() : m_CurrentBufferSize (0)
 }
 ```
 
-```c++
+```c++:PluginProcessor.cpp
 void GigaverbAudioProcessor::prepareToPlay (double sampleRate, int samplesPerBlock)
 {
     m_C74PluginState->sr = sampleRate;
@@ -139,7 +139,7 @@ void GigaverbAudioProcessor::prepareToPlay (double sampleRate, int samplesPerBlo
 }
 ```
 
-```c++
+```c++:PluginProcessor.cpp
 void GigaverbAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages)
 {
     for (int i = 0; i < gen_exported::num_inputs(); i++)
@@ -177,7 +177,7 @@ void GigaverbAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, juc
 }
 ```
 
-```c++
+```c++:PluginProcessor.cpp
 void GigaverbAudioProcessor::assureBufferSize (long bufferSize)
 {
     if (bufferSize > m_CurrentBufferSize)
@@ -203,7 +203,7 @@ void GigaverbAudioProcessor::assureBufferSize (long bufferSize)
 }
 ```
 
-```c++
+```c++:PluginProcessor.cpp
 void GigaverbAudioProcessor::parameterChanged (const juce::String& parameterID, float newValue)
 {
     auto index = apvts.getParameter(parameterID)->getParameterIndex();
@@ -211,7 +211,7 @@ void GigaverbAudioProcessor::parameterChanged (const juce::String& parameterID, 
 }
 ```
 
-```c++
+```c++:PluginProcessor.cpp
 juce::AudioProcessorValueTreeState::ParameterLayout GigaverbAudioProcessor::createParameterLayout()
 {
     m_C74PluginState = (CommonState*) gen_exported::create (44100, 64);
@@ -257,7 +257,7 @@ Finally, Source directory looks like the following:
 
 #### ModernDial.h/.cpp
 
-```c++
+```c++:ModernDial.h
 #pragma once
 
 #include <JuceHeader.h>
@@ -285,7 +285,7 @@ private:
 };
 ```
 
-```c++
+```c++:ModernDial.cpp
 #include "ModernDial.h"
 
 ModernDial::ModernDial()
@@ -358,7 +358,7 @@ void ModernDial::mouseUp (const juce::MouseEvent& event)
 
 #### CustomLookAndFeel.h/.cpp
 
-```c++
+```c++:CustomLookAndFeel.h
 #pragma once
 
 #include <JuceHeader.h>
@@ -387,7 +387,7 @@ private:
 };
 ```
 
-```c++
+```c++:CustomLookAndFeel.cpp
 #include "CustomLookAndFeel.h"
 
 CustomLookAndFeel::CustomLookAndFeel() {};
@@ -470,7 +470,7 @@ juce::Label* CustomLookAndFeel::createSliderTextBox (juce::Slider& slider)
 
 #### NameLabel.h
 
-```c++
+```c++:NameLabel.h
 #pragma once
 
 #include <JuceHeader.h>
@@ -494,7 +494,7 @@ private:
 
 Prepare the necessary member variables and functions.
 
-```c++
+```c++:PluginEditor.h
 class GigaverbAudioProcessorEditor  : public juce::AudioProcessorEditor
 {
 ・・・
@@ -536,7 +536,7 @@ private:
 };
 ```
 
-```c++
+```c++:PluginEditor.cpp
 GigaverbAudioProcessorEditor::GigaverbAudioProcessorEditor (GigaverbAudioProcessor& p)
     : AudioProcessorEditor (&p), audioProcessor (p),
       roomsizeAttachment  (audioProcessor.apvts, "roomsize",  roomsizeDial),
@@ -576,14 +576,14 @@ GigaverbAudioProcessorEditor::GigaverbAudioProcessorEditor (GigaverbAudioProcess
 }
 ```
 
-```c++
+```c++:PluginProcessor.cpp
 void GigaverbAudioProcessorEditor::paint (juce::Graphics& g)
 {
     g.fillAll (black);
 }
 ```
 
-```c++
+```c++:PluginProcessor.cpp
 void GigaverbAudioProcessorEditor::resized()
 {
     roomsizeDial.setBounds  (50,  70,  70, 70);
@@ -597,7 +597,7 @@ void GigaverbAudioProcessorEditor::resized()
 }
 ```
 
-```c++
+```c++:PluginProcessor.cpp
 std::vector<ModernDial*> GigaverbAudioProcessorEditor::getDials()
 {
     return

--- a/posts/jg-granular.md
+++ b/posts/jg-granular.md
@@ -14,7 +14,7 @@ The source code and patch for JG-Granular are available from the repository belo
 
 [szkkng/JG-Granular](https://github.com/szkkng/jg-granular)
 
-```text
+```text:CommandLine
 $ git clone https://github.com/szkkng/jg-granular.git
 ```
 
@@ -50,7 +50,7 @@ In this article, I will focus on how to implement using APVTS, so I will omit ex
 
 In order to reflect the changes in the parameters managed by APVTS to the parameters of the exported gen~ object, we use the [AudioProcessorValueTreeState::Listener:: parameterChanged()](https://docs.juce.com/master/structAudioProcessorValueTreeState_1_1Listener.html#a2716fa16ef99141f599ffd7c93682552) function.
 
-```c++
+```c++:PluginProcessor.h
 class JGGranularAudioProcessor  : public juce::AudioProcessor, public juce::AudioProcessorValueTreeState::Listener
 {
 public:
@@ -68,7 +68,7 @@ private:
 
 Then, use [AudioProcessorValueTreeState::addParameterListener()](https://docs.juce.com/master/classAudioProcessorValueTreeState.html#a350478cad727aa6ceac20e1c933446fc) to register a callback.
 
-```c++
+```c++:PluginProcessor.cpp
 JGGranularAudioProcessor::JGGranularAudioProcessor() : m_CurrentBufferSize (0)
 {
 ・・・
@@ -82,7 +82,7 @@ JGGranularAudioProcessor::JGGranularAudioProcessor() : m_CurrentBufferSize (0)
 
 The implementation part of parameterChanged() is as follows:
 
-```c++
+```c++:PluginProcessor.cpp
 void JGGranularAudioProcessor::parameterChanged (const juce::String& parameterID, float newValue)
 {
     auto index = apvts.getParameter (parameterID)->getParameterIndex();
@@ -94,7 +94,7 @@ To set a new parameter for the exported gen~ object, use the gen_exported::setpa
 
 If you want to check the indexes of these parameters, call gen_exported::getparametername() and output it to the console.
 
-```c++
+```c++:PluginProcessor.cpp
 JGGranularAudioProcessor::JGGranularAudioProcessor() : m_CurrentBufferSize (0)
 {
 ・・・
@@ -121,7 +121,7 @@ width
 
 As you can see, the parameters are assigned an index in alphabetical order. In this case, the parameter that the user manipulates is anything other than data_param. Therefore, in order to map this index to the parameter index of APVTS, pass index plus 1 as the argument of setparameter() in parameterChanged() above. Then, add the parameters to be managed by APVTS to the layout in alphabetical order as shown below. In this way, the indexes of the parameters in gen~ can be mapped to the indexes of the parameters managed by APVTS.
 
-```c++
+```c++:PluginProcessor.cpp
 juce::AudioProcessorValueTreeState::ParameterLayout JGGranularAudioProcessor::createParameterLayout()
 {
     APVTS::ParameterLayout layout;

--- a/posts/numberbox.md
+++ b/posts/numberbox.md
@@ -38,9 +38,7 @@ NumberBox is mainly a component that can be dragged to change its value, so it i
 
 First, I will show the entire implementation of the .h/.cpp file, and then I will explain the key points.
 
-NumberBox.h:
-
-```c++
+```c++:NumberBox.h
 #pragma once
 
 #include <JuceHeader.h>
@@ -57,9 +55,7 @@ public:
 };
 ```
 
-NumberBox.cpp:
-
-```c++
+```c++:NumberBox.cpp
 #include "NumberBox.h"
 
 NumberBox::NumberBox()
@@ -171,13 +167,13 @@ Okay, now that we have the basic functionality of the NumberBox implemented, let
 
 Include NumberBox.h near the top in the MainComponent.h file:
 
-```c++
+```c++:MainComponent.h
 #include "NumberBox.h"
 ```
 
 Next, let's declare three-color NumberBox objects as shown below:
 
-```c++
+```c++:MainComponent.h
 class MainComponent  : public juce::Component
 {
 public:
@@ -196,7 +192,7 @@ private:
 
 Finally, edit MainComponent.cpp as shown below:
 
-```c++
+```c++:MainComponent.cpp
 MainComponent::MainComponent()
 {
     setSize (500, 300);
@@ -250,7 +246,7 @@ In this chapter, we will change the color of the caret and make sure that the lo
 The member functions for setting the appearance of the caret and NumberBox are [createCaretComponent()](https://docs.juce.com/master/classLookAndFeel__V2.html#a8dbedf25e46dffd17384ae01e822dac4) and [createSliderTextBox()](https://docs.juce.com/master/classLookAndFeel__V4.html#ab08d5aa50750b1989c99a052073f96b1), respectively.
 Let's declare CustomLookAndFeel class at the top in the NumberBox.h file and override these functions.
 
-```c++
+```c++:NumberBox.h
 class CustomLookAndFeel : public juce::LookAndFeel_V4
 {
 public:
@@ -261,7 +257,7 @@ public:
 
 Then, let's declare CustomLookAndFeel class object in NumberBox class.
 
-```c++
+```c++:NumberBox.h
 class NumberBox  : public juce::Slider, public juce::KeyListener
 {
 public:
@@ -274,7 +270,7 @@ private:
 
 The definition part of the two overridden functions looks like the following:
 
-```c++
+```c++:NumberBox.cpp
 juce::CaretComponent* CustomLookAndFeel::createCaretComponent (juce::Component* keyFocusOwner)
 {
     auto caret = new juce::CaretComponent (keyFocusOwner);
@@ -302,7 +298,7 @@ In createCaretComponent(), we set the color of the caret to the same color as th
 
 Then, call setLookAndFeel() to apply CustomLookAndFeel to NumberBox.
 
-```c++
+```c++:NumberBox.cpp
 NumberBox::NumberBox()
 {
     setLookAndFeel (&customLookAndFeel);
@@ -333,9 +329,7 @@ Also, when juce::Label detects a key input and displays juce::TextEditor, the fi
 
 Based on the above, Numberbox.h/.cpp will look like the following.
 
-NumberBox.h:
-
-```c++
+```c++:NumberBox.h
 class CustomLabel : public juce::Label
 {
 public:
@@ -346,7 +340,7 @@ public:
 };
 ```
 
-```c++
+```c++:NumberBox.h
 class CustomLookAndFeel : public juce::LookAndFeel_V4
 {
 public:
@@ -355,9 +349,7 @@ public:
 };
 ```
 
-NumberBox.cpp:
-
-```c++
+```c++:NumberBox.cpp
 juce::String CustomLabel::initialPressedKey = "";
 
 juce::TextEditor* CustomLabel::createEditorComponent()
@@ -379,7 +371,7 @@ void CustomLabel::editorShown (juce::TextEditor* editor)
 }
 ```
 
-```c++
+```c++:NumberBox.cpp
 CustomLabel* CustomLookAndFeel::createSliderTextBox (juce::Slider& slider)
 {
     auto* l = new CustomLabel();
@@ -395,7 +387,7 @@ Then, the variable introduced here, initialPressedKey, will take effect through 
 
 Let's override [keyPressed()](https://docs.juce.com/master/classKeyListener.html#ae69d788cbada2ae5069a9e725db0baf7), a member function of the component class that is called when the component has gained keyboard focus and a key is pressed.
 
-```c++
+```c++:NumberBox.h
 class NumberBox  : public juce::Slider
 {
 public:
@@ -404,7 +396,7 @@ public:
 
 ```
 
-```c++
+```c++:NumberBox.cpp
 bool NumberBox::keyPressed (const juce::KeyPress& k)
 {
     char numChars[] = "0123456789";
@@ -430,7 +422,7 @@ Only numeric key input is allowed, and the first key pressed is passed to the st
 
 Also, in order to allow NumberBox to gain keyboard focus, pass true to the setWantsKeyboardFocus function, in this case we have already set this function:
 
-```
+```c++:NumberBox.cpp
 NumberBox::NumberBox()
 {
 ・・・

--- a/posts/simple-reverb.md
+++ b/posts/simple-reverb.md
@@ -30,7 +30,7 @@ This chapter explains the DSP part of Simple Reverb.
 
 I recommend using APVTS(AudioProcessorValueTreeState) to manage parameters because it is so much simpler than the traditional way. Prepare the APVTS object as shown below:
 
-```c++
+```c++:PluginProcessor.h
 class SimpleReverbAudioProcessor  : public juce::AudioProcessor
 {
 public:
@@ -51,7 +51,7 @@ Implement all the parameters that you want to manage in APVTS in createParameter
 
 These parameters can be made to correspond to knobs one by one, but it is inconvenient to have separate Dry and Wet parameters, so they are combined into one as "dw". Also, I personally think it is cooler to display the parameters as %. These implementations are shown below:
 
-```c++
+```c++:PluginProcessor.cpp
 juce::AudioProcessorValueTreeState::ParameterLayout SimpleReverbAudioProcessor::createParameterLayout()
 {
     juce::AudioProcessorValueTreeState::ParameterLayout layout;
@@ -127,7 +127,7 @@ juce::AudioProcessorValueTreeState::ParameterLayout SimpleReverbAudioProcessor::
 
 Now that the APVTS is ready, we will implement the Reverb part. Let’s create an object of juce::dsp::Reverb::Parameters, which was introduced earlier. Also, create two juce::dsp::Reverb objects to support stereo channels.
 
-```c++
+```c++:PluginProcessor.h
 class SimpleReverbAudioProcessor  : public juce::AudioProcessor
 {
 ・・・
@@ -141,7 +141,7 @@ private:
 
 Next, prepare a juce::dsp::ProcessSpec object to hold the information necessary to initialize the Reverb object you have created:
 
-```c++
+```c++:PluginProcessor.cpp
 void SimpleReverbAudioProcessor::prepareToPlay (double sampleRate, int samplesPerBlock)
 {
     juce::dsp::ProcessSpec spec;
@@ -157,7 +157,7 @@ void SimpleReverbAudioProcessor::prepareToPlay (double sampleRate, int samplesPe
 
 Then, we will implement the audio processing part. As mentioned earlier, we’ll combine them into one as "dw", so we’ll give it a little twist. It means that the value of dry should be the maximum value of 1 minus the value of wet. Like this:
 
-```c++
+```c++:PluginProcessor.cpp
 void SimpleReverbAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages)
 {
     juce::ScopedNoDenormals noDenormals;
@@ -196,7 +196,7 @@ Now, the implementation of the dsp part is complete.
 By editing as show below, you can check the operation with the UI provided by default in JUCE.
 Don't forget to change it back after checking.
 
-```c++
+```c++:PluginProcessor.cpp
 juce::AudioProcessorEditor* SimpleReverbAudioProcessor::createEditor()
 {
 //    return new SimpleReverbAudioProcessorEditor (*this);
@@ -216,7 +216,7 @@ First, we will customize LookAndFeel, which is the foundation of the UI componen
 
 The implementation details of the header file are as shown below:
 
-```c++
+```c++:CustomLookAndFeel.h
 #pragma once
 
 #include <JuceHeader.h>
@@ -260,7 +260,7 @@ I will explain the member functions to be overridden one by one.
 
 Simple Reverb’s RotarySlider is designed to place a text box in the center:
 
-```c++
+```c++:CustomLookAndFeel.cpp
 juce::Slider::SliderLayout CustomLookAndFeel::getSliderLayout (juce::Slider& slider)
 {
     auto localBounds = slider.getLocalBounds();
@@ -280,7 +280,7 @@ juce::Slider::SliderLayout CustomLookAndFeel::getSliderLayout (juce::Slider& sli
 
 The RotarySlider of Simple Reverb is implemented as follows:
 
-```c++
+```c++:CustomLookAndFeel.cpp
 void CustomLookAndFeel::drawRotarySlider (juce::Graphics& g, int x, int y, int width, int height, float sliderPos,
                                           const float rotaryStartAngle, const float rotaryEndAngle, juce::Slider& slider)
 {
@@ -337,7 +337,7 @@ void CustomLookAndFeel::drawRotarySlider (juce::Graphics& g, int x, int y, int w
 
 [createSliderTextBox()](https://docs.juce.com/master/classLookAndFeel__V4.html#ab08d5aa50750b1989c99a052073f96b1) is the function involved in depicting the slider text box. We have just overridden getSliderLayout so that the text box is placed in the center of the RotarySlider, but this will interfere with dragging. To allow dragging even on the text box, we can pass false to setInterceptsMouseClicks():
 
-```c++
+```c++:CustomLookAndFeel.cpp
 juce::Label* CustomLookAndFeel::createSliderTextBox (juce::Slider& slider)
 {
     auto* l = new juce::Label();
@@ -356,7 +356,7 @@ juce::Label* CustomLookAndFeel::createSliderTextBox (juce::Slider& slider)
 
 [getTextButtonFont()](https://docs.juce.com/master/classLookAndFeel__V4.html#a74afbc74da0036ed8eae41dfc6a2fd85) is a function related to the font part of the TextButton object. We override this function for “∞”.
 
-```c++
+```c++:CustomLookAndFeel.cpp
 juce::Font CustomLookAndFeel::getTextButtonFont (juce::TextButton&, int buttonHeight)
 {
     return juce::Font { "Avenir Next Medium", 90.f, 0 };
@@ -368,7 +368,7 @@ juce::Font CustomLookAndFeel::getTextButtonFont (juce::TextButton&, int buttonHe
 [drawButtonBackground()](https://docs.juce.com/master/classLookAndFeel__V4.html#a5ecb659ea592de3d703b7eff40e5fb89) is a function related to drawing the background part of a TextButton.
 In this case, we don’t need to draw the border and background of “∞”, so we clear it.
 
-```c++
+```c++:CustomLookAndFeel.cpp
 void CustomLookAndFeel::drawButtonBackground (juce::Graphics& g, juce::Button& button, const juce::Colour& backgroundColour,
                                               bool shouldDrawButtonAsHighlighted, bool shouldDrawButtonAsDown)
 {
@@ -379,7 +379,7 @@ void CustomLookAndFeel::drawButtonBackground (juce::Graphics& g, juce::Button& b
 
 The implementation of the header file is shown below:
 
-```c++
+```c++:RotarySlider.h
 #pragma once
 
 #include <JuceHeader.h>
@@ -412,7 +412,7 @@ private:
 
 In this constructor, the following member functions are called to configure the details.
 
-```c++
+```c++:RotarySlider.cpp
 RotarySlider::RotarySlider()
 {
     setSliderStyle (juce::Slider::SliderStyle::RotaryVerticalDrag);
@@ -440,7 +440,7 @@ RotarySlider::~RotarySlider()
 
 It is implemented so that when the RotarySlider gets the focus, it will be marked as locked on:
 
-```c++
+```c++:RotarySlider.cpp
 void RotarySlider::paint (juce::Graphics& g)
 {
     juce::Slider::paint (g);
@@ -469,7 +469,7 @@ void RotarySlider::paint (juce::Graphics& g)
 
 It is implemented so that the mouse pointer disappears when you click and drag the mouse, and it appears when you release the mouse:
 
-```c++
+```c++:RotarySlider.cpp
 void RotarySlider::mouseDown (const juce::MouseEvent& event)
 {
     juce::Slider::mouseDown (event);
@@ -490,7 +490,7 @@ void RotarySlider::mouseUp (const juce::MouseEvent& event)
 
 This class is customized for the labels that correspond to each knob. If we don’t prepare this, we will have to write the same code multiple times, which is not very beautiful. The amount of code to be written is small, so just create a new header file and implement it as shown below:
 
-```c++
+```c++:NameLabel.h
 #pragma once
 
 #include <JuceHeader.h>
@@ -517,7 +517,7 @@ private:
 
 Now, we have completed the implementation of the UI components that make up Simple Reverb. we just need to implement the PluginEditor part.
 
-```c++
+```c++:PluginEditor.h
 #pragma once
 
 #include <JuceHeader.h>
@@ -576,7 +576,7 @@ private:
 
 The implementation part of this constructor is as shown below:
 
-```c++
+```c++:PluginEditor.cpp
 SimpleReverbAudioProcessorEditor::SimpleReverbAudioProcessorEditor (SimpleReverbAudioProcessor& p)
     : AudioProcessorEditor (&p), audioProcessor (p),
       sizeSliderAttachment (audioProcessor.apvts, "size", sizeSlider),
@@ -626,7 +626,7 @@ SimpleReverbAudioProcessorEditor::~SimpleReverbAudioProcessorEditor()
 
 Fill the background with a smoky black color and depict the text “Simple Reverb”:
 
-```c++
+```c++:PluginEditor.cpp
 void SimpleReverbAudioProcessorEditor::paint (juce::Graphics& g)
 {
     g.fillAll (black);
@@ -641,7 +641,7 @@ void SimpleReverbAudioProcessorEditor::paint (juce::Graphics& g)
 
 The placement and size of each component is shown below:
 
-```c++
+```c++:PluginEditor.cpp
 void SimpleReverbAudioProcessorEditor::resized()
 {
     sizeSlider.setBounds (30, 120, 60, 60);

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import matter from 'gray-matter';
+import rehypeCodeTitles from 'rehype-code-titles';
 import rehypeHighlight from 'rehype-highlight';
 import rehypeStringify from 'rehype-stringify';
 import remarkParse from 'remark-parse';
@@ -60,6 +61,7 @@ export async function getPostData(id: string) {
     .use(remarkParse)
     .use(remarkSlug)
     .use(remarkRehype)
+    .use(rehypeCodeTitles)
     .use(rehypeHighlight)
     .use(rehypeStringify)
     .process(matterResult.content);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -98,10 +98,10 @@
   }
 
   pre > code {
-    @apply text-sm md:font-light rounded-md bg-darkGray bg-opacity-10 border border-darkGray border-opacity-70 shadow p-5 !important;
+    @apply text-sm md:font-light rounded-md rounded-tl-none bg-darkGray bg-opacity-10 border border-darkGray shadow p-5 !important;
   }
   pre {
-    @apply block max-w-full sm:w-auto my-6;
+    @apply block max-w-full sm:w-auto mb-6;
   }
 
   .toc li {
@@ -161,4 +161,8 @@
   .toc .is-active-link {
     @apply text-milkyWhite;
   }
+}
+
+.rehype-code-title {
+  @apply inline-block bg-darkGray border-darkGray rounded-t-md text-milkyWhite py-1 px-3 mt-1 text-xs;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3484,6 +3484,13 @@ regexpp@^3.1.0:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
+rehype-code-titles@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/rehype-code-titles/-/rehype-code-titles-1.0.3.tgz#63968dbc4407ea9e9689bd6e84e5c735ca535d6b"
+  integrity sha512-VBLHA1egC8smTGQ0X2oEPO6kuq+CKHkSBanjKHhW5AhOL9V7qsbiB4GSRGDUHI4gwCWSdM4A4R5aoRZ4UExw6A==
+  dependencies:
+    unist-util-visit "^3.0.0"
+
 rehype-highlight@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/rehype-highlight/-/rehype-highlight-5.0.0.tgz#a1814e31180bcc55c37f66c289df69c3d004ece1"


### PR DESCRIPTION
Added code title feature using retype-code-titles, since remark-code-titles did not work properly.

closes #35 