### PR TITLE
Remove padding of blog cards

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,12 +23,12 @@ export default function Home({ allPostsData }: InferGetServerSidePropsType<typeo
         {allPostsData.map(({ id, date, title, thumbnail }) => (
           <div
             key={id}
-            className='flex flex-col border transition delay-75 border-darkGray p-5 hover:border-cyan'
+            className='flex flex-col border transition delay-75 border-darkGray hover:border-cyan'
           >
             <Link href='posts/[id]' as={`/posts/${id}`}>
-              <a className='flex flex-col justify-between text-milkyWhite mt-2 pl-2 w-full h-full transition delay-75 hover:text-cyan'>
+              <a className='flex flex-col justify-between text-milkyWhite mt-2 p-5 w-full h-full transition delay-75 hover:text-cyan'>
                 <Image src={thumbnail} width={840} height={540} objectFit='contain' alt='' />
-                <div className='text-xl font-bold'>{title}</div>
+                <div className='text-xl font-bold mt-2 pl-2'>{title}</div>
                 <div className='text-lightGray text-sm mt-3 pl-2'>
                   <Date dateString={date} />
                 </div>


### PR DESCRIPTION
Incorrect padding prevented the border of the blog card and the title from changing color together on mouse hover:

<img width="1909" alt="Screen Shot 2021-12-24 at 20 06 30" src="https://user-images.githubusercontent.com/61953352/147348778-fb543c21-ed99-4368-b584-3f5eb644a8ae.png">