### PR TITLE
Use abbreviations for months

### DIFF
--- a/src/components/Date.tsx
+++ b/src/components/Date.tsx
@@ -4,5 +4,5 @@ type Props = { dateString: string };
 
 export const Date: React.FC<Props> = ({ dateString }) => {
   const date = parseISO(dateString);
-  return <time dateTime={dateString}>{format(date, 'LLLL d, yyyy')}</time>;
+  return <time dateTime={dateString}>{format(date, 'LLL d, yyyy')}</time>;
 };


### PR DESCRIPTION
The formatting of the created and updated date was redundant and made it look bad, so I used abbreviations for months to simplify it.